### PR TITLE
Update cas version to 4.0.0-RC4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@
 		<module>cas-overlay-management-demo</module>
 	</modules>
 	<properties>
-		<cas.version>4.0.0-RC4-SNAPSHOT</cas.version>
+		<cas.version>4.0.0-RC4</cas.version>
 	</properties>
 </project>
-


### PR DESCRIPTION
Thanks for the demo project. I cloned and tried to use it personally but found the project to fail building because of the CAS version defined in the POM. If you need the output of the error message I can add that as a comment, just let me know. 

In this case I stuck with the 4.0.0 line of CAS but removed the -SNAPSHOT indicator and it builds perfectly.
